### PR TITLE
Fix Login Submission test 

### DIFF
--- a/__tests__/LoginSubmission-test.tsx
+++ b/__tests__/LoginSubmission-test.tsx
@@ -73,6 +73,6 @@ it('renders correctly', async () => {
   `)
 
   await wait(() => expect(mockNavigate).toHaveBeenCalledTimes(1))
-  expect(mockNavigate).toHaveBeenCalledWith(SCREENS.HOME)
+  expect(mockNavigate).toHaveBeenCalledWith("Home")
   expect(AsyncStorage.setItem).toHaveBeenCalledWith('token', 'fake-token')
 })

--- a/src/components/LoginSubmission.tsx
+++ b/src/components/LoginSubmission.tsx
@@ -86,7 +86,7 @@ export default () => {
   React.useEffect(() => {
     if (token) {
       (async ()=> await AsyncStorage.setItem('token', token))()
-      navigation.navigate(SCREENS.HOME)
+      navigation.navigate("Home")
     }
   }, [token])
 


### PR DESCRIPTION
this weirdly fixes the below error that I saw in the loginsubmission test

```javascript
 FAIL  __tests__/LoginSubmission-test.tsx
  ● Console

    console.error
      [
        'The above error occurred in the <_default> component:\n' +
          '    in _default\n' +
          '    in View (created by View)\n' +
          '    in View (created by AppContainer)\n' +
          '    in View (created by View)\n' +
          '    in View (created by AppContainer)\n' +
          '    in AppContainer (at src/index.js:26)\n' +
          '\n' +
          'Consider adding an error boundary to your tree to customize error handling behavior.\n' +
          'Visit https://fb.me/react-error-boundaries to learn more about error boundaries.'
      ]

      at BufferedConsole.console.error (node_modules/react-native/Libraries/LogBox/LogBox.js:33:14)
      at registerError (node_modules/react-native/Libraries/YellowBox/YellowBox.js:169:7)
      at errorImpl (node_modules/react-native/Libraries/YellowBox/YellowBox.js:84:22)
      at BufferedConsole.console.error (node_modules/react-native/Libraries/YellowBox/YellowBox.js:63:14)
      at BufferedConsole.error (node_modules/@testing-library/react-native/dist/act-compat.js:40:34)
      at logCapturedError (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10141:21)
      at logError (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10178:5)
      at update.callback (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11288:5)

  ● renders correctly

    TypeError: Cannot read property 'HOME' of undefined

      87 |     if (token) {
      88 |       (async ()=> await AsyncStorage.setItem('token', token))()
    > 89 |       navigation.navigate(SCREENS.HOME)
         |                                   ^
      90 |     }
      91 |   }, [token])
      92 | 

      at src/components/LoginSubmission.tsx:89:35
      at commitHookEffectListMount (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10345:26)
      at commitPassiveHookEffects (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10383:11)
      at Object.invokeGuardedCallbackImpl (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:9897:10)
      at invokeGuardedCallback (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:10073:31)
      at flushPassiveEffectsImpl (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13345:9)
      at unstable_runWithPriority (node_modules/react-test-renderer/node_modules/scheduler/cjs/scheduler.development.js:653:12)
      at runWithPriority (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1775:10)
      at flushPassiveEffects (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13312:12)
      at node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13191:11
```