### PR TITLE
Fix version number for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "prettier": "^2.1.1",
     "react-native-testing-library": "^6.0.0",
     "react-test-renderer": "16.13.1",
-    "typescript": "^4.02"
+    "typescript": "^4.0.2"
   }
 }


### PR DESCRIPTION
Running `npm install` was failing because `"^4.02"` is not a valid version number.